### PR TITLE
Update uDSV.d.ts

### DIFF
--- a/dist/uDSV.d.ts
+++ b/dist/uDSV.d.ts
@@ -67,6 +67,9 @@ export interface SchemaColumn {
 }
 
 export interface Schema {
+    /** inital rows to skip */
+    skip: number;
+	
 	/** column delimiter */
 	col:    string;
 
@@ -74,10 +77,10 @@ export interface Schema {
 	row:    string;
 
 	/** column enclosure */
-	encl:   string;
+	encl?:   string;
 
 	/** column enclosure escape */
-	esc:    string;
+	esc?:    string;
 
 	/** trim values (excludes within quotes) */
 	trim:   boolean;


### PR DESCRIPTION
update type because doesn't match runtime schema

I copied the schema because I wanted to hardcode it  for my particular use case. When I tried to recreate the same schema that I found on runtime, it didn't match

### real schema 
```ts 

{
  "skip": 1,
  "col": "\t",
  "row": "\n",
  "trim": false,
  "cols": omitted
}
```