### PR TITLE
Replace const enum in .d.ts with a string literal union

### DIFF
--- a/dist/uDSV.d.ts
+++ b/dist/uDSV.d.ts
@@ -25,23 +25,22 @@ export interface InferSchemaOpts {
 //	omit?,
 }
 
-export const enum SchemaColumnType {
-	String       = 's',
-	Number       = 'n',
-	Date         = 'd',
-	JSON         = 'j',
-	Boolean_1    = 'b:1',
-	Boolean_t    = 'b:t',
-	Boolean_T    = 'b:T',
-	Boolean_true = 'b:true',
-	Boolean_True = 'b:True',
-	Boolean_TRUE = 'b:TRUE',
-	Boolean_y    = 'b:y',
-	Boolean_Y    = 'b:Y',
-	Boolean_yes  = 'b:yes',
-	Boolean_Yes  = 'b:Yes',
-	Boolean_YES  = 'b:YES',
-}
+export type SchemaColumnType = 
+| /** String */ 's'
+| /** Number */ 'n'
+| /** Date */ 'd'
+| /** JSON */ 'j'
+| /** Boolean_1 */ 'b:1'
+| /** Boolean_t */ 'b:t'
+| /** Boolean_T */ 'b:T'
+| /** Boolean_true */ 'b:true'
+| /** Boolean_True */ 'b:True'
+| /** Boolean_TRUE */ 'b:TRUE'
+| /** Boolean_y */ 'b:y'
+| /** Boolean_Y */ 'b:Y'
+| /** Boolean_yes */ 'b:yes'
+| /** Boolean_Yes */ 'b:Yes'
+| /** Boolean_YES */ 'b:YES';
 
 export interface SchemaColumn {
 	/** column name */


### PR DESCRIPTION
Addresses #15

Note that this is probably a breaking change from the point of view of the types, in case someone has been using `SchemaColumnType.String` etc.