### PR TITLE
Bench/typed: calling csv-simple-parser in a more optimized way

### DIFF
--- a/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
@@ -1,4 +1,4 @@
-const infer = (value, isExplicitlyQuoted) => {
+const infer = value => {
   if (value === '')
     return null;
   if (value === 'FALSE')

--- a/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
@@ -1,12 +1,12 @@
 const infer = (value, isExplicitlyQuoted) => {
-  if (value[0] === '{' || value[0] === '[')
-    return JSON.parse(value);
   if (value === '')
     return null;
   if (value === 'FALSE')
     return false;
   if (value === 'TRUE')
     return true;
+  if (value[0] === '{' || value[0] === '[')
+    return JSON.parse(value);
 
   let asNum = +value;
 

--- a/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
@@ -1,10 +1,6 @@
 const infer = (value, isExplicitlyQuoted) => {
   if (value[0] === '{' || value[0] === '[')
     return JSON.parse(value);
-
-  if (isExplicitlyQuoted)
-    return value;
-
   if (value === '')
     return null;
   if (value === 'FALSE')

--- a/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
@@ -1,5 +1,5 @@
 const transform = (value, x, y, quoted) => {
-  if (value === '')
+  if (value === '' || value === 'null' || value === 'NULL')
     return null;
   if (value === 'FALSE')
     return false;
@@ -24,7 +24,7 @@ module.exports = {
     const { default: parse } = await import('csv-simple-parser');
 
     return (csvStr, path) => new Promise(res => {
-      let rows = parse(csvStr, { infer: true, transform });
+      let rows = parse(csvStr, { transform });
       // console.log(rows[0], rows[1]);
       // process.exit();
       res(rows);

--- a/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-arrs.cjs
@@ -1,13 +1,16 @@
-const transform = (value, x, y, quoted) => {
-  if (value === '' || value === 'null' || value === 'NULL')
+const infer = (value, isExplicitlyQuoted) => {
+  if (value[0] === '{' || value[0] === '[')
+    return JSON.parse(value);
+
+  if (isExplicitlyQuoted)
+    return value;
+
+  if (value === '')
     return null;
   if (value === 'FALSE')
     return false;
   if (value === 'TRUE')
     return true;
-
-  if (value[0] === '{' || value[0] === '[')
-    return JSON.parse(value);
 
   let asNum = +value;
 
@@ -24,7 +27,7 @@ module.exports = {
     const { default: parse } = await import('csv-simple-parser');
 
     return (csvStr, path) => new Promise(res => {
-      let rows = parse(csvStr, { transform });
+      let rows = parse(csvStr, { infer });
       // console.log(rows[0], rows[1]);
       // process.exit();
       res(rows);

--- a/bench/non-streaming/typed/csv-simple-parser-objs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-objs.cjs
@@ -1,4 +1,4 @@
-const infer = (value, isExplicitlyQuoted) => {
+const infer = value => {
   if (value === '')
     return null;
   if (value === 'FALSE')

--- a/bench/non-streaming/typed/csv-simple-parser-objs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-objs.cjs
@@ -1,12 +1,12 @@
 const infer = (value, isExplicitlyQuoted) => {
-  if (value[0] === '{' || value[0] === '[')
-    return JSON.parse(value);
   if (value === '')
     return null;
   if (value === 'FALSE')
     return false;
   if (value === 'TRUE')
     return true;
+  if (value[0] === '{' || value[0] === '[')
+    return JSON.parse(value);
 
   let asNum = +value;
 

--- a/bench/non-streaming/typed/csv-simple-parser-objs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-objs.cjs
@@ -1,10 +1,6 @@
 const infer = (value, isExplicitlyQuoted) => {
   if (value[0] === '{' || value[0] === '[')
     return JSON.parse(value);
-
-  if (isExplicitlyQuoted)
-    return value;
-
   if (value === '')
     return null;
   if (value === 'FALSE')

--- a/bench/non-streaming/typed/csv-simple-parser-objs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-objs.cjs
@@ -1,5 +1,5 @@
 const transform = (value, x, y, quoted) => {
-  if (value === '')
+  if (value === '' || value === 'null' || value === 'NULL')
     return null;
   if (value === 'FALSE')
     return false;
@@ -24,7 +24,7 @@ module.exports = {
     const { default: parse } = await import('csv-simple-parser');
 
     return (csvStr, path) => new Promise(res => {
-      let rows = parse(csvStr, { infer: true, header: true, transform });
+      let rows = parse(csvStr, { header: true, transform });
       res(rows);
     });
   },

--- a/bench/non-streaming/typed/csv-simple-parser-objs.cjs
+++ b/bench/non-streaming/typed/csv-simple-parser-objs.cjs
@@ -1,13 +1,16 @@
-const transform = (value, x, y, quoted) => {
-  if (value === '' || value === 'null' || value === 'NULL')
+const infer = (value, isExplicitlyQuoted) => {
+  if (value[0] === '{' || value[0] === '[')
+    return JSON.parse(value);
+
+  if (isExplicitlyQuoted)
+    return value;
+
+  if (value === '')
     return null;
   if (value === 'FALSE')
     return false;
   if (value === 'TRUE')
     return true;
-
-  if (value[0] === '{' || value[0] === '[')
-    return JSON.parse(value);
 
   let asNum = +value;
 
@@ -24,7 +27,7 @@ module.exports = {
     const { default: parse } = await import('csv-simple-parser');
 
     return (csvStr, path) => new Promise(res => {
-      let rows = parse(csvStr, { header: true, transform });
+      let rows = parse(csvStr, { header: true, infer });
       res(rows);
     });
   },

--- a/bench/package.json
+++ b/bench/package.json
@@ -28,7 +28,7 @@
     "csv-parser": "^3.1.0",
     "csv-parser-2": "^1.0.1",
     "csv-rex": "^0.7.0",
-    "csv-simple-parser": "^1.0.3",
+    "csv-simple-parser": "^2.0.0",
     "csv42": "^5.0.3",
     "csvtojson": "^2.0.10",
     "d3-dsv": "^3.0.1",


### PR DESCRIPTION
I think `csv-simple-parser` was being called inefficiently, effectively executing 2 transform functions on the value, when we could just execute one. 

I've changed how this is implemented in v2 of the library to incentivize always using the library in the more optimized way.

Also I've reworked the custom infer function a bit to make use of the "isExplicitlyQuoted" argument. That changes how it works slightly though, it would break things if we don't actually want `"0"` to be interpreted as `"0"` but rather as `0`. If we want that to be interpreted as `0` the check for `isExplicitlyQuoted` should be deleted basically.

Lastly I've changed the built-in infer function, which now is slightly slower, though this benchmark doesn't seem to use that at all now so that should be irrelevant for it.

Presumably this change should make `csv-simple-parser` perform a little bitter in this benchmark, but I haven't rerun the benchmark myself, fingers crossed, super curious to see the result 🤞